### PR TITLE
Add Content Type to support UTF-8 messages

### DIFF
--- a/PS-Pushover.psm1
+++ b/PS-Pushover.psm1
@@ -341,7 +341,7 @@ Function Send-PushoverMessage{
     }  
 
     # Send the message
-    $parameters | Invoke-RestMethod -Uri "https://api.pushover.net/1/messages.json" -Method Post
+    $parameters | Invoke-RestMethod -Uri "https://api.pushover.net/1/messages.json" -Method Post -ContentType "application/x-www-form-urlencoded; charset=utf-8"
 }
 
 <#


### PR DESCRIPTION
To support non US-ascii characters the message need to be sent with UTF-8 charset specified.
Content-Type set based on specifications found in official API documentation https://pushover.net/api#messages